### PR TITLE
Removed hardcoded path in GeometryBuilder

### DIFF
--- a/ios/Classes/GeometryBuilder.m
+++ b/ios/Classes/GeometryBuilder.m
@@ -91,7 +91,7 @@
         
         if(img == nil)
         {
-            NSString* asset_path = [@"assets/images/" stringByAppendingString:propertyString[@"image"]];
+            NSString* asset_path = propertyString[@"image"];
             NSString* path = [[NSBundle mainBundle] pathForResource:[[ArkitPlugin registrar] lookupKeyForAsset:asset_path] ofType:nil];
             img = [UIImage imageNamed: path];
         }


### PR DESCRIPTION
- Images loaded from flutter can be stored in arbitrary locations instead of /assets/images/.
- The full path of the file must be specified (path root is the root of the Flutter application).