### PR TITLE
Update widget_projection.dart

### DIFF
--- a/example/lib/image_detection_page.dart
+++ b/example/lib/image_detection_page.dart
@@ -40,7 +40,7 @@ class _ImageDetectionPageState extends State<ImageDetectionPage> {
                         'Point the camera at the earth image from the article about Earth on Wikipedia.',
                         style: Theme.of(context)
                             .textTheme
-                            .headline
+                            .headline5
                             .copyWith(color: Colors.white),
                       ),
                     ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -191,11 +191,11 @@ class SampleItem extends StatelessWidget {
           leading: Icon(item.icon),
           title: Text(
             item.title,
-            style: Theme.of(context).textTheme.subhead,
+            style: Theme.of(context).textTheme.subtitle1,
           ),
           subtitle: Text(
             item.description,
-            style: Theme.of(context).textTheme.subtitle,
+            style: Theme.of(context).textTheme.subtitle2,
           ),
         ),
       ),

--- a/example/lib/network_image_detection.dart
+++ b/example/lib/network_image_detection.dart
@@ -47,7 +47,7 @@ class _NetworkImageDetectionPageState extends State<NetworkImageDetectionPage> {
                         'Point the camera at Mars photo from the article about Mars on Wikipedia.',
                         style: Theme.of(context)
                             .textTheme
-                            .headline
+                            .headline5
                             .copyWith(color: Colors.white),
                       ),
                     ),

--- a/example/lib/widget_projection.dart
+++ b/example/lib/widget_projection.dart
@@ -140,7 +140,7 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
             Text(
               '$_counter',
-              style: Theme.of(context).textTheme.display1,
+              style: Theme.of(context).textTheme.headline4,
             ),
           ],
         ),


### PR DESCRIPTION
Thanks for an amazing library 🙌🏻. I wanted to make this small change.

'display1' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is headline4. This feature was deprecated after v1.13.8.