### PR TITLE
add maximumNumberOfTrackedImages

### DIFF
--- a/ios/Classes/ConfigurationBuilders/ImageTrackingConfigurationBuilder.swift
+++ b/ios/Classes/ConfigurationBuilders/ImageTrackingConfigurationBuilder.swift
@@ -15,7 +15,7 @@ func createImageTrackingConfiguration(_ arguments: Dictionary<String, Any>) -> A
         }
         if #available(iOS 12.0, *) {
             if let maximumNumberOfTrackedImages = arguments["maximumNumberOfTrackedImages"] as? Int {
-                worldTrackingConfiguration.maximumNumberOfTrackedImages = maximumNumberOfTrackedImages
+                imageTrackingConfiguration.maximumNumberOfTrackedImages = maximumNumberOfTrackedImages
             }
         }
         return imageTrackingConfiguration

--- a/ios/Classes/ConfigurationBuilders/ImageTrackingConfigurationBuilder.swift
+++ b/ios/Classes/ConfigurationBuilders/ImageTrackingConfigurationBuilder.swift
@@ -13,6 +13,11 @@ func createImageTrackingConfiguration(_ arguments: Dictionary<String, Any>) -> A
         if let trackingImages = arguments["trackingImages"] as? Array<Dictionary<String, Any>> {
             imageTrackingConfiguration.trackingImages = parseReferenceImagesSet(trackingImages)
         }
+        if #available(iOS 12.0, *) {
+            if let maximumNumberOfTrackedImages = arguments["maximumNumberOfTrackedImages"] as? Int {
+                worldTrackingConfiguration.maximumNumberOfTrackedImages = maximumNumberOfTrackedImages
+            }
+        }
         return imageTrackingConfiguration
     }
     return nil

--- a/ios/Classes/ConfigurationBuilders/WorldTrackingConfigurationBuilder.swift
+++ b/ios/Classes/ConfigurationBuilders/WorldTrackingConfigurationBuilder.swift
@@ -27,6 +27,11 @@ func createWorldTrackingConfiguration(_ arguments: Dictionary<String, Any>) -> A
                 worldTrackingConfiguration.detectionImages = parseReferenceImagesSet(detectionImages)
             }
         }
+        if #available(iOS 12.0, *) {
+            if let maximumNumberOfTrackedImages = arguments["maximumNumberOfTrackedImages"] as? Int {
+                worldTrackingConfiguration.maximumNumberOfTrackedImages = maximumNumberOfTrackedImages
+            }
+        }
         return worldTrackingConfiguration
     }
     return nil

--- a/lib/widget/arkit_scene_view.dart
+++ b/lib/widget/arkit_scene_view.dart
@@ -59,6 +59,7 @@ class ARKitSceneView extends StatefulWidget {
     this.trackingImages,
     this.forceUserTapOnCenter = false,
     this.worldAlignment = ARWorldAlignment.gravity,
+    this.maximumNumberOfTrackedImages,
     this.debug = false,
   }) : super(key: key);
 
@@ -138,6 +139,9 @@ class ARKitSceneView extends StatefulWidget {
   /// The default is false.
   final bool forceUserTapOnCenter;
 
+  /// When set enables image tracking using worldTracking configuration
+  final int maximumNumberOfTrackedImages;
+
   /// When true prints all communication between the plugin and the framework.
   /// The default is false;
   final bool debug;
@@ -182,6 +186,7 @@ class _ARKitSceneViewState extends State<ARKitSceneView> {
       widget.trackingImagesGroupName,
       widget.trackingImages,
       widget.forceUserTapOnCenter,
+      widget.maximumNumberOfTrackedImages,
       widget.debug,
     ));
   }
@@ -210,6 +215,7 @@ class ARKitController {
     String trackingImagesGroupName,
     List<ARKitReferenceImage> trackingImages,
     bool forceUserTapOnCenter,
+    int maximumNumberOfTrackedImages,
     this.debug,
   ) {
     _channel = MethodChannel('arkit_$id');
@@ -231,6 +237,7 @@ class ARKitController {
       'trackingImages': trackingImages?.map((i) => i.toJson())?.toList(),
       'forceUserTapOnCenter': forceUserTapOnCenter,
       'worldAlignment': worldAlignment.index,
+      'maximumNumberOfTrackedImages': maximumNumberOfTrackedImages,
     });
   }
 

--- a/lib/widget/arkit_scene_view.dart
+++ b/lib/widget/arkit_scene_view.dart
@@ -142,6 +142,7 @@ class ARKitSceneView extends StatefulWidget {
   /// Maximum number of images to track simultaneously. 
   /// Setting the maximum number of tracked images will limit the number of images that can be tracked in a given frame. 
   /// If more than the maximum is visible, only the images already being tracked will continue to track until tracking is lost or another image is removed.
+  /// The default is 0
   final int maximumNumberOfTrackedImages;
 
   /// When true prints all communication between the plugin and the framework.

--- a/lib/widget/arkit_scene_view.dart
+++ b/lib/widget/arkit_scene_view.dart
@@ -59,7 +59,7 @@ class ARKitSceneView extends StatefulWidget {
     this.trackingImages,
     this.forceUserTapOnCenter = false,
     this.worldAlignment = ARWorldAlignment.gravity,
-    this.maximumNumberOfTrackedImages,
+    this.maximumNumberOfTrackedImages = 0,
     this.debug = false,
   }) : super(key: key);
 
@@ -139,7 +139,9 @@ class ARKitSceneView extends StatefulWidget {
   /// The default is false.
   final bool forceUserTapOnCenter;
 
-  /// When set enables image tracking using worldTracking configuration
+  /// Maximum number of images to track simultaneously. 
+  /// Setting the maximum number of tracked images will limit the number of images that can be tracked in a given frame. 
+  /// If more than the maximum is visible, only the images already being tracked will continue to track until tracking is lost or another image is removed.
   final int maximumNumberOfTrackedImages;
 
   /// When true prints all communication between the plugin and the framework.


### PR DESCRIPTION
Setting maximumNumberOfTrackedImages inside the ARKitSceneView constructor enables image tracking using worldTracking configuration.