### PR TITLE
Dispose method now releases the main ARKit resource

### DIFF
--- a/ios/Classes/FlutterArkitView+GesutreRecognizer.swift
+++ b/ios/Classes/FlutterArkitView+GesutreRecognizer.swift
@@ -11,7 +11,7 @@ extension FlutterArkitView: UIGestureRecognizerDelegate {
             if (enableTap) {
                 let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
                 tapGestureRecognizer.delegate = self
-                self.sceneView.gestureRecognizers?.append(tapGestureRecognizer)
+                self.sceneView?.gestureRecognizers?.append(tapGestureRecognizer)
             }
         }
         
@@ -19,7 +19,7 @@ extension FlutterArkitView: UIGestureRecognizerDelegate {
             if (enablePinch) {
                 let pinchGestureRecognizer = UIPinchGestureRecognizer(target: self, action: #selector(handlePinch(_:)))
                 pinchGestureRecognizer.delegate = self
-                self.sceneView.gestureRecognizers?.append(pinchGestureRecognizer)
+                self.sceneView?.gestureRecognizers?.append(pinchGestureRecognizer)
             }
         }
 
@@ -27,7 +27,7 @@ extension FlutterArkitView: UIGestureRecognizerDelegate {
             if (enablePan) {
                 let panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
                 panGestureRecognizer.delegate = self
-                self.sceneView.gestureRecognizers?.append(panGestureRecognizer)
+                self.sceneView?.gestureRecognizers?.append(panGestureRecognizer)
             }
         }
         
@@ -35,7 +35,7 @@ extension FlutterArkitView: UIGestureRecognizerDelegate {
             if (enableRotation) {
                 let rotationGestureRecognizer = UIRotationGestureRecognizer(target: self, action: #selector(handleRotation(_:)))
                 rotationGestureRecognizer.delegate = self
-                self.sceneView.gestureRecognizers?.append(rotationGestureRecognizer)
+                self.sceneView?.gestureRecognizers?.append(rotationGestureRecognizer)
             }
         }
     }
@@ -45,7 +45,9 @@ extension FlutterArkitView: UIGestureRecognizerDelegate {
         guard let sceneView = recognizer.view as? ARSCNView else {
             return
         }
-        let touchLocation = self.forceTapOnCenter ? self.sceneView.center : recognizer.location(in: sceneView)
+        guard let touchLocation = self.forceTapOnCenter ? self.sceneView?.center : recognizer.location(in: sceneView) else {
+            return
+        }
         let hitResults = sceneView.hitTest(touchLocation, options: nil)
         let results: Array<String> = hitResults.compactMap { $0.node.name }
         if (results.count != 0) {

--- a/ios/Classes/FlutterArkitView+Handlers.swift
+++ b/ios/Classes/FlutterArkitView+Handlers.swift
@@ -3,13 +3,13 @@ import ARKit
 extension FlutterArkitView {
     func onAddNode(_ arguments: Dictionary<String, Any>) {
         let geometryArguments = arguments["geometry"] as? Dictionary<String, Any>
-        let geometry = createGeometry(geometryArguments, withDevice: sceneView.device)
-        let node = createNode(geometry, fromDict: arguments, forDevice: sceneView.device)
+        let geometry = createGeometry(geometryArguments, withDevice: sceneView?.device)
+        let node = createNode(geometry, fromDict: arguments, forDevice: sceneView?.device)
         if let parentNodeName = arguments["parentNodeName"] as? String {
-            let parentNode = sceneView.scene.rootNode.childNode(withName: parentNodeName, recursively: true)
+            let parentNode = sceneView?.scene.rootNode.childNode(withName: parentNodeName, recursively: true)
             parentNode?.addChildNode(node)
         } else {
-            sceneView.scene.rootNode.addChildNode(node)
+            sceneView?.scene.rootNode.addChildNode(node)
         }
     }
     
@@ -18,7 +18,7 @@ extension FlutterArkitView {
             logPluginError("nodeName deserialization failed", toChannel: channel)
             return
         }
-        let node = sceneView.scene.rootNode.childNode(withName: nodeName, recursively: true)
+        let node = sceneView?.scene.rootNode.childNode(withName: nodeName, recursively: true)
         node?.removeFromParentNode()
     }
   
@@ -27,8 +27,8 @@ extension FlutterArkitView {
             logPluginError("anchorIdentifier deserialization failed", toChannel: channel)
             return
         }
-        if let anchor = sceneView.session.currentFrame?.anchors.first(where:{ $0.identifier.uuidString == anchorIdentifier }) {
-            sceneView.session.remove(anchor: anchor)
+        if let anchor = sceneView?.session.currentFrame?.anchors.first(where:{ $0.identifier.uuidString == anchorIdentifier }) {
+            sceneView?.session.remove(anchor: anchor)
         }
     }
     
@@ -38,8 +38,8 @@ extension FlutterArkitView {
             result(nil)
             return
         }
-        let geometry = createGeometry(geometryArguments, withDevice: sceneView.device)
-        let node = createNode(geometry, fromDict: arguments, forDevice: sceneView.device)
+        let geometry = createGeometry(geometryArguments, withDevice: sceneView?.device)
+        let node = createNode(geometry, fromDict: arguments, forDevice: sceneView?.device)
         
         let resArray = [serializeVector(node.boundingBox.min), serializeVector(node.boundingBox.max)]
         result(resArray)
@@ -52,7 +52,7 @@ extension FlutterArkitView {
                 logPluginError("deserialization failed", toChannel: channel)
                 return
         }
-        if let node = sceneView.scene.rootNode.childNode(withName: name, recursively: true) {
+        if let node = sceneView?.scene.rootNode.childNode(withName: name, recursively: true) {
             node.transform = deserializeMatrix4(params)
         } else {
             logPluginError("node not found", toChannel: channel)
@@ -66,7 +66,7 @@ extension FlutterArkitView {
                 logPluginError("deserialization failed", toChannel: channel)
                 return
         }
-        if let node = sceneView.scene.rootNode.childNode(withName: name, recursively: true) {
+        if let node = sceneView?.scene.rootNode.childNode(withName: name, recursively: true) {
             node.isHidden = params
         } else {
             logPluginError("node not found", toChannel: channel)
@@ -84,7 +84,7 @@ extension FlutterArkitView {
                 return
         }
         
-        if let node = sceneView.scene.rootNode.childNode(withName: name, recursively: true) {
+        if let node = sceneView?.scene.rootNode.childNode(withName: name, recursively: true) {
             if let obj = node.value(forKey: keyProperty) as? NSObject {
                 obj.setValue(propertyValue, forKey: propertyName)
             } else {
@@ -102,7 +102,7 @@ extension FlutterArkitView {
                 logPluginError("deserialization failed", toChannel: channel)
                 return
         }
-        if let node = sceneView.scene.rootNode.childNode(withName: name, recursively: true) {
+        if let node = sceneView?.scene.rootNode.childNode(withName: name, recursively: true) {
             
             let materials = parseMaterials(rawMaterials)
             node.geometry?.materials = materials
@@ -141,15 +141,19 @@ extension FlutterArkitView {
                 result(nil)
                 return
         }
-        let viewWidth = sceneView.bounds.size.width
-        let viewHeight = sceneView.bounds.size.height
+        guard let viewWidth = sceneView?.bounds.size.width else {
+             return
+        }
+        guard let viewHeight = sceneView?.bounds.size.height else {
+             return
+        }
         let location = CGPoint(x: viewWidth * CGFloat(x), y: viewHeight * CGFloat(y));
-        let arHitResults = getARHitResultsArray(sceneView, atLocation: location)
+        let arHitResults = getARHitResultsArray(sceneView ?? ARSCNView(), atLocation: location)
         result(arHitResults)
     }
     
     func onGetLightEstimate(_ result:FlutterResult) {
-        let frame = sceneView.session.currentFrame
+        let frame = sceneView?.session.currentFrame
         if let lightEstimate = frame?.lightEstimate {
             let res = ["ambientIntensity": lightEstimate.ambientIntensity, "ambientColorTemperature": lightEstimate.ambientColorTemperature]
             result(res)
@@ -165,13 +169,15 @@ extension FlutterArkitView {
             return
         }
         let point = deserizlieVector3(rawPoint)
-        let projectedPoint = sceneView.projectPoint(point)
+        guard let projectedPoint = sceneView?.projectPoint(point) else {
+            return
+        }
         let res = serializeVector(projectedPoint)
         result(res)
     }
     
     func onCameraProjectionMatrix(_ result:FlutterResult) {
-        if let frame = sceneView.session.currentFrame {
+        if let frame = sceneView?.session.currentFrame {
             let matrix = serializeMatrix(frame.camera.projectionMatrix)
             result(matrix)
         } else {
@@ -180,7 +186,7 @@ extension FlutterArkitView {
     }
   
     func onPointOfViewTransform(_ result:FlutterResult) {
-        if let pointOfView = sceneView.pointOfView {
+        if let pointOfView = sceneView?.pointOfView {
           let matrix = serializeMatrix(pointOfView.simdWorldTransform)
             result(matrix)
         } else {
@@ -202,7 +208,7 @@ extension FlutterArkitView {
             animation.repeatCount = 1
             animation.fadeInDuration = 1
             animation.fadeOutDuration = 0.5
-            sceneView.scene.rootNode.addAnimation(animation, forKey: key)
+            sceneView?.scene.rootNode.addAnimation(animation, forKey: key)
         } else {
             logPluginError("animation failed", toChannel: channel)
         }
@@ -213,6 +219,6 @@ extension FlutterArkitView {
             logPluginError("deserialization failed", toChannel: channel)
             return
         }
-        sceneView.scene.rootNode.removeAnimation(forKey: key)
+        sceneView?.scene.rootNode.removeAnimation(forKey: key)
     }
 }

--- a/ios/Classes/FlutterArkitView+Initialization.swift
+++ b/ios/Classes/FlutterArkitView+Initialization.swift
@@ -3,11 +3,11 @@ import ARKit
 extension FlutterArkitView {
     func initalize(_ arguments: Dictionary<String, Any>, _ result:FlutterResult) {
         if let showStatistics = arguments["showStatistics"] as? Bool {
-            self.sceneView.showsStatistics = showStatistics
+            self.sceneView?.showsStatistics = showStatistics
         }
         
         if let autoenablesDefaultLighting = arguments["autoenablesDefaultLighting"] as? Bool {
-            self.sceneView.autoenablesDefaultLighting = autoenablesDefaultLighting
+            self.sceneView?.autoenablesDefaultLighting = autoenablesDefaultLighting
         }
         
         if let forceUserTapOnCenter = arguments["forceUserTapOnCenter"] as? Bool {
@@ -16,10 +16,11 @@ extension FlutterArkitView {
         
         initalizeGesutreRecognizers(arguments)
         
-        sceneView.debugOptions = parseDebugOptions(arguments)
+        sceneView?.debugOptions = parseDebugOptions(arguments)
         configuration = parseConfiguration(arguments)
         if (configuration != nil) {
-            self.sceneView.session.run(self.configuration!)
+            self.sceneView?.session.run(self.configuration!, options: [.resetTracking,
+                 .removeExistingAnchors])
         }
     }
     

--- a/ios/Classes/FlutterArkitView.swift
+++ b/ios/Classes/FlutterArkitView.swift
@@ -2,23 +2,31 @@ import Foundation
 import ARKit
 
 class FlutterArkitView: NSObject, FlutterPlatformView {
-    let sceneView: ARSCNView
+    var sceneView: ARSCNView?
     let channel: FlutterMethodChannel
     
     var forceTapOnCenter: Bool = false
     var configuration: ARConfiguration? = nil
     
     init(withFrame frame: CGRect, viewIdentifier viewId: Int64, messenger msg: FlutterBinaryMessenger) {
+        
+        
         self.sceneView = ARSCNView(frame: frame)
         self.channel = FlutterMethodChannel(name: "arkit_\(viewId)", binaryMessenger: msg)
-        
         super.init()
         
-        self.sceneView.delegate = self
+        self.sceneView?.delegate = self
         self.channel.setMethodCallHandler(self.onMethodCalled)
     }
     
-    func view() -> UIView { return sceneView }
+    func view() -> UIView {
+        
+        guard let scene = self.sceneView else {
+            return UIView()
+        }
+        return scene
+        
+    }
     
     func onMethodCalled(_ call :FlutterMethodCall, _ result:FlutterResult) {
         let arguments = call.arguments as? Dictionary<String, Any>
@@ -104,7 +112,8 @@ class FlutterArkitView: NSObject, FlutterPlatformView {
     }
     
     func onDispose(_ result:FlutterResult) {
-        sceneView.session.pause()
+        self.sceneView?.session.pause()
+        self.sceneView = nil
         result(nil)
     }
 }


### PR DESCRIPTION
Every time the AR page was being used (e.g. closing & reopening several times) the sceneView was holding up a lot of memory (my testing was 100MB+ memory each time AR opened, without any assets loading). The sceneView is now optional but guards have been placed where sceneView was referenced to avoid runtime exceptions.