### PR TITLE
Exposing Camera Euler Angles

### DIFF
--- a/ios/Classes/FlutterArkitView+Handlers.swift
+++ b/ios/Classes/FlutterArkitView+Handlers.swift
@@ -215,4 +215,17 @@ extension FlutterArkitView {
         }
         sceneView.scene.rootNode.removeAnimation(forKey: key)
     }
+
+    func onCameraEulerAngles(_ result:FlutterResult){
+        if let frame = sceneView.session.currentFrame {
+            let eulerAnglesObj = frame.camera.eulerAngles
+            var anglesArray: [Double] = [Double(eulerAnglesObj.x), Double(eulerAnglesObj.y), Double(eulerAnglesObj.z)]
+            let point = deserizlieVector3(anglesArray)
+            let res = serializeVector(point)
+            result(res)
+        } else {
+            result(nil)
+        }
+   }
+
 }

--- a/ios/Classes/FlutterArkitView+Handlers.swift
+++ b/ios/Classes/FlutterArkitView+Handlers.swift
@@ -219,9 +219,8 @@ extension FlutterArkitView {
     func onCameraEulerAngles(_ result:FlutterResult){
         if let frame = sceneView.session.currentFrame {
             let cameraEulerAngles = frame.camera.eulerAngles
-            var eulerAnglesArray: [Double] = [Double(cameraEulerAngles.x), Double(cameraEulerAngles.y), Double(cameraEulerAngles.z)]
-            let point = deserizlieVector3(eulerAnglesArray)
-            let res = serializeVector(point)
+            var eulerAnglesVector = SCNVector3(cameraEulerAngles.x, cameraEulerAngles.y, cameraEulerAngles.z)
+            let res = serializeVector(eulerAnglesVector)
             result(res)
         } else {
             result(nil)

--- a/ios/Classes/FlutterArkitView+Handlers.swift
+++ b/ios/Classes/FlutterArkitView+Handlers.swift
@@ -218,9 +218,9 @@ extension FlutterArkitView {
 
     func onCameraEulerAngles(_ result:FlutterResult){
         if let frame = sceneView.session.currentFrame {
-            let eulerAnglesObj = frame.camera.eulerAngles
-            var anglesArray: [Double] = [Double(eulerAnglesObj.x), Double(eulerAnglesObj.y), Double(eulerAnglesObj.z)]
-            let point = deserizlieVector3(anglesArray)
+            let cameraEulerAngles = frame.camera.eulerAngles
+            var eulerAnglesArray: [Double] = [Double(cameraEulerAngles.x), Double(cameraEulerAngles.y), Double(cameraEulerAngles.z)]
+            let point = deserizlieVector3(eulerAnglesArray)
             let res = serializeVector(point)
             result(res)
         } else {

--- a/ios/Classes/FlutterArkitView.swift
+++ b/ios/Classes/FlutterArkitView.swift
@@ -97,6 +97,9 @@ class FlutterArkitView: NSObject, FlutterPlatformView {
             onDispose(result)
             result(nil)
             break
+        case "cameraEulerAngles":
+            onCameraEulerAngles(result)
+            break
         default:
             result(FlutterMethodNotImplemented)
             break

--- a/lib/widget/arkit_scene_view.dart
+++ b/lib/widget/arkit_scene_view.dart
@@ -688,4 +688,11 @@ class ARKitController {
       ..addAll({paramName: params});
     return values;
   }
+
+  Future<Vector3> _getCameraEulerAngles() async{
+    final result =  await _channel.invokeListMethod('cameraEulerAngles');
+    var vector3 = _vector3Converter.fromJson(result);
+    return vector3;
+  }
+
 }

--- a/lib/widget/arkit_scene_view.dart
+++ b/lib/widget/arkit_scene_view.dart
@@ -689,9 +689,9 @@ class ARKitController {
     return values;
   }
 
-  Future<Vector3> _getCameraEulerAngles() async{
+  Future<Vector3> getCameraEulerAngles() async{
     final result =  await _channel.invokeListMethod('cameraEulerAngles');
-    var vector3 = _vector3Converter.fromJson(result);
+    final vector3 = _vector3Converter.fromJson(result);
     return vector3;
   }
 


### PR DESCRIPTION
For an app I am developing. I needed to position a 2D plane and rotate it initially to face the camera.
That's why I needed to access Camera's EulerAngles and I had to expose it using native Swift method.
My app is now working as required with the local changes I applied to the plugin. And thought about adding that change for others to use.

I hope my change is clean enough for being merged with your main repo.

Thanks,