### PR TITLE
Add null safety check for snapshot and euler angle

### DIFF
--- a/lib/widget/arkit_scene_view.dart
+++ b/lib/widget/arkit_scene_view.dart
@@ -711,14 +711,14 @@ class ARKitController {
 
   Future<Vector3> getCameraEulerAngles() async {
     final result = await (_channel.invokeListMethod('cameraEulerAngles')
-        as FutureOr<List<dynamic>>);
-    final vector3 = _vector3Converter.fromJson(result);
+        as FutureOr<List<dynamic>?>);
+    final vector3 = _vector3Converter.fromJson(result!);
     return vector3;
   }
 
   Future<ImageProvider> snapshot() async {
     final result = await (_channel.invokeMethod<Uint8List>('snapshot')
-        as FutureOr<Uint8List>);
-    return MemoryImage(result);
+        as FutureOr<Uint8List?>);
+    return MemoryImage(result!);
   }
 }


### PR DESCRIPTION
Added null safety to the result of two methods of the arkit_scene_view file. Currently the following error is thrown when executing one of these methods:
`Unhandled Exception: type 'Future<List<dynamic>?>' is not a subtype of type 'FutureOr<List<dynamic>>' in type cast`