### PR TITLE
fix type in ARKitPlugin.checkConfiguration

### DIFF
--- a/example/lib/check_support_page.dart
+++ b/example/lib/check_support_page.dart
@@ -20,10 +20,11 @@ class CheckSupportPage extends StatelessWidget {
       FutureBuilder<bool>(
           future: ARKitPlugin.checkConfiguration(configuration),
           builder: (context, snapshot) {
-            if (!snapshot.hasData) {
+            final data = snapshot.data;
+            if (data == null) {
               return Text(' loading');
             }
-            return Text(snapshot.data ? ' supported' : ' not supported');
+            return Text(data ? ' supported' : ' not supported');
           })
     ]);
   }

--- a/example/lib/check_support_page.dart
+++ b/example/lib/check_support_page.dart
@@ -20,11 +20,10 @@ class CheckSupportPage extends StatelessWidget {
       FutureBuilder<bool>(
           future: ARKitPlugin.checkConfiguration(configuration),
           builder: (context, snapshot) {
-            final data = snapshot.data;
-            if (data == null) {
+            if (!snapshot.hasData) {
               return Text(' loading');
             }
-            return Text(data ? ' supported' : ' not supported');
+            return Text(snapshot.data ? ' supported' : ' not supported');
           })
     ]);
   }

--- a/lib/arkit_plugin.dart
+++ b/lib/arkit_plugin.dart
@@ -49,9 +49,9 @@ class ARKitPlugin {
 
   ARKitPlugin._();
 
-  static Future<bool?> checkConfiguration(ARKitConfiguration configuration) {
+  static Future<bool> checkConfiguration(ARKitConfiguration configuration) {
     return _channel.invokeMethod<bool>('checkConfiguration', {
       'configuration': configuration.index,
-    });
+    }).then((value) => value!);
   }
 }

--- a/lib/arkit_plugin.dart
+++ b/lib/arkit_plugin.dart
@@ -49,9 +49,9 @@ class ARKitPlugin {
 
   ARKitPlugin._();
 
-  static Future<bool> checkConfiguration(ARKitConfiguration configuration) {
+  static Future<bool?> checkConfiguration(ARKitConfiguration configuration) {
     return _channel.invokeMethod<bool>('checkConfiguration', {
       'configuration': configuration.index,
-    }) as Future<bool>;
+    });
   }
 }


### PR DESCRIPTION
The cast fails because _channel.invokeMethod<T>
returns a Future<T?>, so don’t cast and pass the
? on to the caller.