### PR TITLE
Enhance ARKit initialization by adding onInitialized callback

### DIFF
--- a/ios/Classes/FlutterArkitView+Initialization.swift
+++ b/ios/Classes/FlutterArkitView+Initialization.swift
@@ -17,15 +17,18 @@ extension FlutterArkitView {
         initalizeGesutreRecognizers(arguments)
 
         sceneView.debugOptions = parseDebugOptions(arguments)
-        
-        configuration = parseConfiguration(arguments)
-        DispatchQueue.main.async {
-            if let config = self.configuration {
-                self.sceneView.session.run(config)
-            } else {
-                logPluginError("Failed to create ARConfiguration", toChannel: self.channel)
+        Task {
+            configuration = parseConfiguration(arguments)
+            DispatchQueue.main.async {
+                if let config = self.configuration {
+                    self.sceneView.session.run(config)
+                    self.sendToFlutter("onInitialized", arguments: nil)
+                } else {
+                    logPluginError("Failed to create ARConfiguration", toChannel: self.channel)
+                }
             }
         }
+        
     }
 
     func parseDebugOptions(_ arguments: [String: Any]) -> SCNDebugOptions {

--- a/lib/src/widget/arkit_scene_view.dart
+++ b/lib/src/widget/arkit_scene_view.dart
@@ -167,6 +167,14 @@ class ARKitSceneView extends StatefulWidget {
 }
 
 class _ARKitSceneViewState extends State<ARKitSceneView> {
+  ARKitController? _controller;
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     if (defaultTargetPlatform == TargetPlatform.iOS) {
@@ -181,7 +189,7 @@ class _ARKitSceneViewState extends State<ARKitSceneView> {
   }
 
   Future<void> onPlatformViewCreated(int id) async {
-    widget.onARKitViewCreated(ARKitController._init(
+    _controller = ARKitController._init(
       id,
       widget.configuration,
       widget.environmentTexturing,
@@ -202,7 +210,8 @@ class _ARKitSceneViewState extends State<ARKitSceneView> {
       widget.forceUserTapOnCenter,
       widget.maximumNumberOfTrackedImages,
       widget.debug,
-    ));
+      widget.onARKitViewCreated,
+    );
   }
 }
 
@@ -232,6 +241,7 @@ class ARKitController {
     bool forceUserTapOnCenter,
     int maximumNumberOfTrackedImages,
     this.debug,
+    this.onARKitViewCreated,
   ) {
     _channel = MethodChannel('arkit_$id');
     _channel.setMethodCallHandler(_platformCallHandler);
@@ -303,6 +313,8 @@ class ARKitController {
   /// the AR experience.
   /// For example, when coaching is deactivated, your app might restore custom UI.
   VoidCallback? coachingOverlayViewDidDeactivate;
+
+  final ARKitPluginCreatedCallback onARKitViewCreated;
 
   final bool debug;
 
@@ -462,6 +474,9 @@ class ARKitController {
     }
     try {
       switch (call.method) {
+        case 'onInitialized':
+          onARKitViewCreated(this);
+          break;
         case 'onError':
           if (onError != null) {
             onError!(call.arguments);

--- a/lib/src/widget/arkit_scene_view.dart
+++ b/lib/src/widget/arkit_scene_view.dart
@@ -317,6 +317,7 @@ class ARKitController {
   final ARKitPluginCreatedCallback onARKitViewCreated;
 
   final bool debug;
+  bool _wasDisposed = false;
 
   static const _boolConverter = ValueNotifierConverter();
   static const _vector3Converter = Vector3Converter();
@@ -329,6 +330,10 @@ class ARKitController {
   static const _stateReasonConverter = ARTrackingStateReasonConverter();
 
   void dispose() {
+    if (_wasDisposed) {
+      return;
+    }
+    _wasDisposed = true;
     _channel.invokeMethod<void>('dispose');
   }
 


### PR DESCRIPTION
This pull request introduces improvements to the ARKit Flutter plugin by ensuring proper controller lifecycle management and providing a callback when the ARKit view is initialized. The changes help prevent resource leaks and allow developers to react to the ARKit session being ready.

**Controller lifecycle management:**

* Added disposal of the `ARKitController` in the `_ARKitSceneViewState`'s `dispose` method to prevent resource leaks.

**Initialization callback improvements:**

* Modified the ARKit view initialization flow to store the controller instance and trigger the `onARKitViewCreated` callback only after the native AR session is fully initialized. 
* Added a new `onInitialized` method call from iOS native code (`FlutterArkitView+Initialization.swift`) to notify Dart when the AR session is ready.
* Updated the `ARKitController` to accept and store the `onARKitViewCreated` callback, and to invoke it when receiving the `onInitialized` event from native code. 