### PR TITLE
Detect more than 100 images

### DIFF
--- a/ios/Classes/FlutterArkitView+Initialization.swift
+++ b/ios/Classes/FlutterArkitView+Initialization.swift
@@ -57,10 +57,13 @@ extension FlutterArkitView {
         var arguments = baseArguments
         arguments["detectionImages"] = batchImages
         configuration = parseConfiguration(arguments)
-
-        sceneView.session.run(configuration!, options: [.removeExistingAnchors])
-        if(isInitialization) {
-            self.sendToFlutter("onInitialized", arguments: nil)
+        if let config = self.configuration {
+            self.sceneView.session.run(config, options: [.removeExistingAnchors])
+            if(isInitialization) {
+                self.sendToFlutter("onInitialized", arguments: nil)
+            }
+        } else {
+            logPluginError("Failed to create ARConfiguration", toChannel: self.channel)
         }
 
         // Allocate time per batch (Apple-approved behavior)

--- a/ios/Classes/FlutterArkitView+Initialization.swift
+++ b/ios/Classes/FlutterArkitView+Initialization.swift
@@ -58,7 +58,7 @@ extension FlutterArkitView {
         arguments["detectionImages"] = batchImages
         configuration = parseConfiguration(arguments)
 
-        sceneView.session.run(configuration!, options: [.resetTracking])
+        sceneView.session.run(configuration!, options: [.removeExistingAnchors])
         if(isInitialization) {
             self.sendToFlutter("onInitialized", arguments: nil)
         }

--- a/ios/Classes/FlutterArkitView+Initialization.swift
+++ b/ios/Classes/FlutterArkitView+Initialization.swift
@@ -17,76 +17,81 @@ extension FlutterArkitView {
         initalizeGesutreRecognizers(arguments)
 
         sceneView.debugOptions = parseDebugOptions(arguments)
-        Task {
-            let allImages = arguments["detectionImages"] as? [[String: Any]] ?? []
-            if(allImages.count > 100) {
-                let imageBatches = stride(from: 0, to: allImages.count, by: 100).map {
-                            Array(allImages[$0..<min($0 + 100, allImages.count)])
-                        }
+        
+        // Check for large sets of images to detect (World Tracking) or track (Image Tracking)
+        let detectionImages = arguments["detectionImages"] as? [[String: Any]] ?? []
+        let trackingImages = arguments["trackingImages"] as? [[String: Any]] ?? []
+        
+        let (allImages, key) = !detectionImages.isEmpty
+            ? (detectionImages, "detectionImages")
+            : (trackingImages, "trackingImages")
 
-                        DispatchQueue.main.async {
-                            self.runImageDetectionBatches(
-                                baseArguments: arguments,
-                                imageBatches: imageBatches,
-                                isInitialization: true
-                            )
-                        }
-            } else {
-                configuration = parseConfiguration(arguments)
-                DispatchQueue.main.async {
-                    if let config = self.configuration {
-                        self.sceneView.session.run(config)
-                        self.sendToFlutter("onInitialized", arguments: nil)
-                    } else {
-                        logPluginError("Failed to create ARConfiguration", toChannel: self.channel)
-                    }
-                }
+        if allImages.count > 100 {
+            let imageBatches = stride(from: 0, to: allImages.count, by: 100).map {
+                Array(allImages[$0..<min($0 + 100, allImages.count)])
             }
-            
+            runImageDetectionBatches(
+                baseArguments: arguments,
+                imageKey: key,
+                imageBatches: imageBatches,
+                sendInitialized: true
+            )
+        } else {
+            runConfiguration(arguments, sendInitialized: true)
+        }
+    }
+    
+    private func runConfiguration(_ arguments: [String: Any], sendInitialized: Bool) {
+        guard !isDisposed else { return }
+        
+        configuration = parseConfiguration(arguments)
+        
+        guard let config = configuration else {
+            logPluginError("Failed to create ARConfiguration", toChannel: channel)
+            return
         }
         
+        // Do NOT use .removeExistingAnchors to preserve the world state
+        sceneView.session.run(config)
+        
+        if sendInitialized {
+            sendToFlutter("onInitialized", arguments: nil)
+        }
     }
     
     private func runImageDetectionBatches(
         baseArguments: [String: Any],
+        imageKey: String,
         imageBatches: [[Any]],
         batchIndex: Int = 0,
-        isInitialization: Bool = false
+        sendInitialized: Bool = false
     ) {
-        let batchImages = imageBatches[batchIndex]
+        guard !isDisposed else { return }
+        
         var arguments = baseArguments
-        arguments["detectionImages"] = batchImages
-        configuration = parseConfiguration(arguments)
-        if let config = self.configuration {
-            self.sceneView.session.run(config, options: [.removeExistingAnchors])
-            if(isInitialization) {
-                self.sendToFlutter("onInitialized", arguments: nil)
-            }
-        } else {
-            logPluginError("Failed to create ARConfiguration", toChannel: self.channel)
-        }
-
-        // Allocate time per batch (Apple-approved behavior)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-            self.runImageDetectionBatches(
+        arguments[imageKey] = imageBatches[batchIndex]
+        
+        runConfiguration(arguments, sendInitialized: sendInitialized)
+        
+        // Schedule next batch rotation
+        let nextIndex = (batchIndex + 1) % imageBatches.count
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+            self?.runImageDetectionBatches(
                 baseArguments: baseArguments,
+                imageKey: imageKey,
                 imageBatches: imageBatches,
-                batchIndex: batchIndex == imageBatches.count - 1 ? 0 : batchIndex + 1
+                batchIndex: nextIndex
             )
         }
     }
 
     func parseDebugOptions(_ arguments: [String: Any]) -> SCNDebugOptions {
         var options = ARSCNDebugOptions().rawValue
-        if let showFeaturePoint = arguments["showFeaturePoints"] as? Bool {
-            if showFeaturePoint {
-                options |= ARSCNDebugOptions.showFeaturePoints.rawValue
-            }
+        if arguments["showFeaturePoints"] as? Bool == true {
+            options |= ARSCNDebugOptions.showFeaturePoints.rawValue
         }
-        if let showWorldOrigin = arguments["showWorldOrigin"] as? Bool {
-            if showWorldOrigin {
-                options |= ARSCNDebugOptions.showWorldOrigin.rawValue
-            }
+        if arguments["showWorldOrigin"] as? Bool == true {
+            options |= ARSCNDebugOptions.showWorldOrigin.rawValue
         }
         return ARSCNDebugOptions(rawValue: options)
     }
@@ -130,14 +135,10 @@ extension FlutterArkitView {
     }
 
     func parseWorldAlignment(_ arguments: [String: Any]) -> ARConfiguration.WorldAlignment {
-        if let worldAlignment = arguments["worldAlignment"] as? Int {
-            if worldAlignment == 0 {
-                return .gravity
-            }
-            if worldAlignment == 1 {
-                return .gravityAndHeading
-            }
+        switch arguments["worldAlignment"] as? Int {
+        case 0: return .gravity
+        case 1: return .gravityAndHeading
+        default: return .camera
         }
-        return .camera
     }
 }

--- a/ios/Classes/FlutterArkitView+Initialization.swift
+++ b/ios/Classes/FlutterArkitView+Initialization.swift
@@ -18,17 +18,59 @@ extension FlutterArkitView {
 
         sceneView.debugOptions = parseDebugOptions(arguments)
         Task {
-            configuration = parseConfiguration(arguments)
-            DispatchQueue.main.async {
-                if let config = self.configuration {
-                    self.sceneView.session.run(config)
-                    self.sendToFlutter("onInitialized", arguments: nil)
-                } else {
-                    logPluginError("Failed to create ARConfiguration", toChannel: self.channel)
+            let allImages = arguments["detectionImages"] as? [[String: Any]] ?? []
+            if(allImages.count > 100) {
+                let imageBatches = stride(from: 0, to: allImages.count, by: 100).map {
+                            Array(allImages[$0..<min($0 + 100, allImages.count)])
+                        }
+
+                        DispatchQueue.main.async {
+                            self.runImageDetectionBatches(
+                                baseArguments: arguments,
+                                imageBatches: imageBatches,
+                                isInitialization: true
+                            )
+                        }
+            } else {
+                configuration = parseConfiguration(arguments)
+                DispatchQueue.main.async {
+                    if let config = self.configuration {
+                        self.sceneView.session.run(config)
+                        self.sendToFlutter("onInitialized", arguments: nil)
+                    } else {
+                        logPluginError("Failed to create ARConfiguration", toChannel: self.channel)
+                    }
                 }
             }
+            
         }
         
+    }
+    
+    private func runImageDetectionBatches(
+        baseArguments: [String: Any],
+        imageBatches: [[Any]],
+        batchIndex: Int = 0,
+        isInitialization: Bool = false
+    ) {
+        let batchImages = imageBatches[batchIndex]
+        var arguments = baseArguments
+        arguments["detectionImages"] = batchImages
+        configuration = parseConfiguration(arguments)
+
+        sceneView.session.run(configuration!, options: [.resetTracking])
+        if(isInitialization) {
+            self.sendToFlutter("onInitialized", arguments: nil)
+        }
+
+        // Allocate time per batch (Apple-approved behavior)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            self.runImageDetectionBatches(
+                baseArguments: baseArguments,
+                imageBatches: imageBatches,
+                batchIndex: batchIndex == imageBatches.count - 1 ? 0 : batchIndex + 1
+            )
+        }
     }
 
     func parseDebugOptions(_ arguments: [String: Any]) -> SCNDebugOptions {

--- a/ios/Classes/FlutterArkitView.swift
+++ b/ios/Classes/FlutterArkitView.swift
@@ -7,6 +7,7 @@ class FlutterArkitView: NSObject, FlutterPlatformView {
 
     var forceTapOnCenter: Bool = false
     var configuration: ARConfiguration? = nil
+    var isDisposed: Bool = false
 
     init(withFrame frame: CGRect, viewIdentifier viewId: Int64, messenger msg: FlutterBinaryMessenger) {
         sceneView = ARSCNView(frame: frame)


### PR DESCRIPTION
This pull request introduces logic to handle a large number of detection images during ARKit view initialization by batching them to avoid overloading the AR session. The main change is the addition of a batching mechanism that processes detection images in groups of up to 100, running each batch sequentially with a delay, which improves stability and reliability when initializing with many images.

**ARKit image detection batching:**

* Added logic to check if the number of detection images exceeds 100 in the `FlutterArkitView` initialization; if so, splits images into batches of 100 and processes them sequentially to prevent ARKit session overload.
* Implemented the `runImageDetectionBatches` private method to handle running each batch, updating the configuration and AR session for each, and scheduling the next batch with a delay to comply with Apple’s recommended behavior.